### PR TITLE
city-movement-speed

### DIFF
--- a/conf/default/map.conf
+++ b/conf/default/map.conf
@@ -254,3 +254,7 @@ daily_tally_limit: 50000
 
 #Increases chance to learn Blue Mage spells. Retail is 33% chance, set to >= 77 to garauntee spells are learned.
 blue_spell_learn_chance: 17
+
+#Increase movement speed while in cities
+city_speed_mod: 50
+

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -234,6 +234,9 @@ uint8 CBattleEntity::GetSpeed()
     else if (objtype == TYPE_PC || objtype == TYPE_PET)
     {
         bonus = map_config.speed_mod;
+        if (loc.zone->GetType() == ZONE_TYPE::CITY) {
+            bonus += map_config.city_speed_mod;
+        }
     }
 
     int16 startingSpeed = isMounted() ? 40 + map_config.mount_speed_mod : speed + bonus;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1010,6 +1010,7 @@ int32 map_config_default()
     map_config.all_jobs_widescan           = true;
     map_config.speed_mod                   = 0;
     map_config.mount_speed_mod             = 0;
+    map_config.city_speed_mod              = 0;
     map_config.mob_speed_mod               = 0;
     map_config.skillup_chance_multiplier   = 1.0f;
     map_config.craft_chance_multiplier     = 1.0f;
@@ -1323,6 +1324,10 @@ int32 map_config_read(const int8* cfgName)
         else if (strcmp(w1, "speed_mod") == 0)
         {
             map_config.speed_mod = atoi(w2);
+        }
+        else if (strcmp(w1, "city_speed_mod") == 0)
+        {
+            map_config.city_speed_mod = atoi(w2);
         }
         else if (strcmp(w1, "mount_speed_mod") == 0)
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -90,6 +90,7 @@ struct map_config_t
     bool        disable_gear_scaling;        // Disables ability to equip higher level gear when level cap/sync effect is on player.
     bool        all_jobs_widescan;           // Enable/disable jobs other than BST and RNG having widescan.
     int8        speed_mod;                   // Modifier to add to player speed
+    int8        city_speed_mod;              // Modifier to add to player speed when in a city
     int8        mount_speed_mod;             // Modifier to add to mount speed
     int8        mob_speed_mod;               // Modifier to add to monster speed
     float       skillup_chance_multiplier;   // Constant used in the skillup formula that has a strong effect on skill-up rates


### PR DESCRIPTION
this adds the ability to mod city run speeds independently of regular run speeds.  Allowing moving through town to be less tedious.