### PR TITLE
[fix] Remove Spectral Jig onUseAbility return

### DIFF
--- a/scripts/globals/abilities/spectral_jig.lua
+++ b/scripts/globals/abilities/spectral_jig.lua
@@ -29,8 +29,7 @@ ability_object.onUseAbility = function(player, target, ability)
     else
         ability:setMsg(tpz.msg.basic.NO_EFFECT) -- no effect on player.
     end
-
-    return 1
+    
 end
 
 return ability_object


### PR DESCRIPTION
This is more of a test. This return seems unnecessary, otherwise I'm not sure what the problem is.