### PR TITLE
fix(ephemoral): allow storage of crystals up to 50000

### DIFF
--- a/scripts/globals/ephemeral.lua
+++ b/scripts/globals/ephemeral.lua
@@ -9,7 +9,7 @@ tpz = tpz or {}
 tpz.ephemeral = {}
 
 -- Cap per crystal type that can be stored. Retail/Default is 5000
-local CrystalCap = 5000
+local CrystalCap = 50000
 
 -- Information for currency storage and event params
 local crystalData =


### PR DESCRIPTION
this changes the default storage capacity of emphemoral moogles to 50000 rather than 5000 since there are only 6 characters on the server