### PR TITLE
[feature] Ignore nation for conquest purchases

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -614,6 +614,10 @@ local function getArg6(player)
     return player:getRank() + (player:getNation() * 32)
 end
 
+local function getArg6IgnoreNation(player, guardNation)
+    return player:getRank() + (guardNation * 32)
+end
+
 -----------------------------------
 -- (LOCAL) overseer stock
 -----------------------------------
@@ -1023,7 +1027,10 @@ tpz.conquest.overseerOnTrigger = function(player, npc, guardNation, guardType, g
         local a6 = getArg6(player)
         local a7 = player:getCP()
         local a8 = getExForceReward(player, guardNation)
-
+        
+        if IGNORE_NATION_FOR_CONQUEST_PURCHASE = 1 then
+            a6 = getArg6IgnoreNation(player,guardNation)
+        
         player:startEvent(guardEvent, a1, a2, a3, a4, a5, a6, a7, a8)
 
     -- OUTPOST AND BORDER OVERSEERS

--- a/scripts/globals/settings.lua
+++ b/scripts/globals/settings.lua
@@ -189,3 +189,4 @@ STARTING_WARP_RING = 1 -- Set to 1 to grant a warp ring at character creation.
 ALWAYS_ALLOW_CHOCOBO_RENTAL = 0 -- Set to 1 to always allow a chocobo rental without a license or any level.
 FREE_HOMEPOINT_TELEPORTS = 1 -- Set to 1 to make Homepoint Teleporting free.
 DISABLE_DROPTYPE_ONE = 1 -- Disables "grouped loot" tpye, giving each item a chance to drop in a group
+IGNORE_NATION_FOR_CONQUEST_PURCHASE = 1 -- When purchasing from Conquest Items from Nation Guard will display all items regardless of Nation or conquest rank


### PR DESCRIPTION
This is a test really but I think I'm on the right path.  The only thing I want to override is really which menu shows up client side.  Otherwise I think the previous PR should work.